### PR TITLE
Added "Edit" menu with 3 functions for opening json files and folders

### DIFF
--- a/laser-calculator.py
+++ b/laser-calculator.py
@@ -66,6 +66,10 @@ class Calculator(ttk.Frame):
         self.menubar.add_cascade(menu=self.menu_options,label="Options")
         self.menu_options.add_command(label="Show history",command=self.show_history,image=self.p_history,compound=tk.LEFT,accelerator="Ctrl+H")
         self.menu_options.add_command(label="Clear history",command=self.clear_history,image=self.p_clear,compound=tk.LEFT)
+        self.menubar.add_cascade(menu=self.edit_options,label="Edit")
+        self.edit_options.add_command(label="Open functions.json",command=print("Hi1"))
+        self.edit_options.add_command(label="Open constants.json",command=print("Hi2"))
+        self.edit_options.add_command(label="Open formulas folder",command=print("Hi3"))
         self.history_window_open = False
         self.bind_all("<Control-KeyPress-h>",self.show_history)
 

--- a/laser-calculator.py
+++ b/laser-calculator.py
@@ -66,6 +66,7 @@ class Calculator(ttk.Frame):
         self.menubar.add_cascade(menu=self.menu_options,label="Options")
         self.menu_options.add_command(label="Show history",command=self.show_history,image=self.p_history,compound=tk.LEFT,accelerator="Ctrl+H")
         self.menu_options.add_command(label="Clear history",command=self.clear_history,image=self.p_clear,compound=tk.LEFT)
+        self.edit_options = tk.Menu(self.menubar)
         self.menubar.add_cascade(menu=self.edit_options,label="Edit")
         self.edit_options.add_command(label="Open functions.json",command=print("Hi1"))
         self.edit_options.add_command(label="Open constants.json",command=print("Hi2"))

--- a/laser-calculator.py
+++ b/laser-calculator.py
@@ -6,7 +6,10 @@ import json
 import sympy
 import copy
 import datetime
+import os
+import subprocess
 
+dir = os.path.dirname(__file__)
 
 
 class Calculator(ttk.Frame):    
@@ -68,9 +71,9 @@ class Calculator(ttk.Frame):
         self.menu_options.add_command(label="Clear history",command=self.clear_history,image=self.p_clear,compound=tk.LEFT)
         self.edit_options = tk.Menu(self.menubar)
         self.menubar.add_cascade(menu=self.edit_options,label="Edit")
-        self.edit_options.add_command(label="Open functions.json",command=print("Hi1"))
-        self.edit_options.add_command(label="Open constants.json",command=print("Hi2"))
-        self.edit_options.add_command(label="Open formulas folder",command=print("Hi3"))
+        self.edit_options.add_command(label="Open functions.json",command=lambda: os.startfile(f"{dir}\\functions.json"))
+        self.edit_options.add_command(label="Open constants.json",command=lambda: os.startfile(f"{dir}\\constants.json"))
+        self.edit_options.add_command(label="Open formulas folder",command=lambda: subprocess.call(f"explorer {dir}\\formulas"))
         self.history_window_open = False
         self.bind_all("<Control-KeyPress-h>",self.show_history)
 


### PR DESCRIPTION
### Added "Edit" menu with 3 functions for opening JSON files and folders
[Original issue link](https://github.com/SargonCZ/laser-calculator/issues/7)

- os module is used for getting the path and opening the files.
- subprocess module is for opening the folder
- The first option, "Open functions.json" opens the file in the default editor (VS Code in my case).
- The second option, "Open constants.json" opens the file in the default editor (VS Code in my case).
- The third option, "Open formulas folder" opens the folder.
#### Image:
![image](https://user-images.githubusercontent.com/46566766/148585862-b463079d-e74b-48d9-a73b-60b0079dc2ae.png)
